### PR TITLE
Release 1.3.1: HACS zip_release Installationsfix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: Release
 # der Tag wird hier erstellt, wenn manifest.json in diesem Push geaendert wurde.
 #
 # HACS zip_release: deepseek_conversation.zip muss zu hacs.json "filename" passen.
+# Zip-Inhalt: manifest.json etc. direkt im Archiv-Root (scripts/build_hacs_zip.py).
+# HACS extrahiert nach custom_components/deepseek_conversation/ — kein Domain-Ordner im Zip.
 # HACS laedt dieses Asset bei Install/Update; GitHub download_count -> HACS-Anzeige.
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this integration.
 
 ### Fixed
 - **HACS installation**: release zip no longer creates a nested `deepseek_conversation/deepseek_conversation/` folder; files extract correctly into `custom_components/deepseek_conversation/`.
+- **Recovery from 1.3.0**: if the integration failed to load after installing 1.3.0, update to 1.3.1 via HACS and restart Home Assistant. That restores the correct file layout. Optionally delete `custom_components/deepseek_conversation/` first and reinstall 1.3.1 for a clean folder (an leftover nested subfolder is harmless but may remain after update).
 
 ## [1.3.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this integration.
 
+## [1.3.1] - 2026-07-02
+
+### Fixed
+- **HACS installation**: release zip no longer creates a nested `deepseek_conversation/deepseek_conversation/` folder; files extract correctly into `custom_components/deepseek_conversation/`.
+
 ## [1.3.0] - 2026-07-01
 
 ### Added

--- a/custom_components/deepseek_conversation/manifest.json
+++ b/custom_components/deepseek_conversation/manifest.json
@@ -20,5 +20,5 @@
     "openai>=1.68.2,<3",
     "voluptuous-openapi>=0.2.0,<0.5"
   ],
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,6 @@
   "render_readme": true,
   "content_in_root": false,
   "zip_release": true,
+  "hide_default_branch": true,
   "filename": "deepseek_conversation.zip"
 }

--- a/scripts/build_hacs_zip.py
+++ b/scripts/build_hacs_zip.py
@@ -1,4 +1,9 @@
-"""Build deepseek_conversation.zip for HACS zip_release (see hacs.json, release.yml)."""
+"""Build deepseek_conversation.zip for HACS zip_release (see hacs.json, release.yml).
+
+HACS extracts zip_release archives directly into custom_components/<domain>/.
+The zip must therefore contain integration files at the archive root (manifest.json, …),
+not wrapped in an extra deepseek_conversation/ folder.
+"""
 
 from __future__ import annotations
 
@@ -24,7 +29,7 @@ def main() -> None:
                 continue
             if "__pycache__" in path.parts or path.suffix == ".pyc":
                 continue
-            arc = path.relative_to(REPO_ROOT / "custom_components").as_posix()
+            arc = path.relative_to(SRC).as_posix()
             zf.write(path, arc)
             count += 1
 
@@ -34,22 +39,20 @@ def main() -> None:
 
 def _validate_zip(path: Path) -> None:
     """Fail fast if the archive does not match HACS zip_release expectations."""
-    required = (
-        "deepseek_conversation/manifest.json",
-        "deepseek_conversation/__init__.py",
-    )
+    required = ("manifest.json", "__init__.py")
+    banned_prefixes = ("custom_components/", "deepseek_conversation/")
     with zipfile.ZipFile(path) as zf:
         names = zf.namelist()
-        roots = {n.split("/")[0] for n in names if "/" in n}
-        if roots != {"deepseek_conversation"}:
-            raise SystemExit(
-                f"Invalid zip layout: expected only deepseek_conversation/ at root, got {roots}"
-            )
         missing = [entry for entry in required if entry not in names]
         if missing:
-            raise SystemExit(f"Zip missing required paths: {missing}")
-        if any(n.startswith("custom_components/") for n in names):
-            raise SystemExit("Zip must not include custom_components/ prefix (content_in_root: false)")
+            raise SystemExit(f"Zip missing required paths at archive root: {missing}")
+        if any(
+            name.startswith(prefix) for name in names for prefix in banned_prefixes
+        ):
+            raise SystemExit(
+                "Zip must contain integration files at archive root; "
+                "HACS already extracts into custom_components/<domain>/"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Behebt fehlerhafte HACS-Installation ab 1.3.0: das Release-Zip enthielt einen zusätzlichen `deepseek_conversation/`-Ordner, wodurch Dateien unter `custom_components/deepseek_conversation/deepseek_conversation/` landeten und die Integration nicht lud.
- `build_hacs_zip.py` packt Integrationsdateien jetzt direkt ins Zip-Root (wie HACS `zip_release` erwartet).
- `hide_default_branch: true` in `hacs.json`, da Releases nur per Zip-Asset installierbar sind.
- Release **1.3.1** mit Changelog inkl. Recovery-Hinweis für betroffene 1.3.0-Nutzer.